### PR TITLE
Reduce usage of the message 'artifact' dict

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
                        queue: 'osci-pipelines-queue-15'
                    ],
                    checks: [
-                       [field: '$.artifact.release', expectedValue: '^f40$']
+                       [field: '$.update.release.dist_tag', expectedValue: '^f40$']
                    ]
                )
            ]
@@ -46,8 +46,8 @@ pipeline {
 
                     if (msg) {
 
-                        if (msg['artifact']['builds'].size() > 20) {
-                            echo "There are way too many (${msg['artifact']['builds'].size()} > 20) builds in the update. Skipping..."
+                        if (msg['update']['builds'].size() > 20) {
+                            echo "There are way too many (${msg['update']['builds'].size()} > 20) builds in the update. Skipping..."
                             return
                         }
 


### PR DESCRIPTION
To help with https://pagure.io/fedora-ci/general/issue/436 , this reduces use of the 'artifact' dict from the Bodhi 'update ready for testing' message to only use the 'task_id' values from the 'build' dicts. This will let us simplify the message format in Bodhi.