### PR TITLE
Let's enable rpmdeplint also for non-Rawhide builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
                        queue: 'osci-pipelines-queue-15'
                    ],
                    checks: [
-                       [field: '$.update.release.dist_tag', expectedValue: '^f40$']
+                       [field: '$.update.release.dist_tag', expectedValue: '^f[3-9]{1}[0-9]{1}$']
                    ]
                )
            ]


### PR DESCRIPTION
Requested by community, causing confusion.

https://lists.fedoraproject.org/archives/list/ci@lists.fedoraproject.org/thread/MAOZ2CFOL4Y767RF23OMBUHVXMZZ2WP5/