### PR TITLE
Revert "Let's enable rpmdeplint also for non-Rawhide builds"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
                        queue: 'osci-pipelines-queue-15'
                    ],
                    checks: [
-                       [field: '$.update.release.dist_tag', expectedValue: '^f[3-9]{1}[0-9]{1}$']
+                       [field: '$.update.release.dist_tag', expectedValue: '^f40$']
                    ]
                )
            ]


### PR DESCRIPTION
Reverts fedora-ci/rpmdeplint-trigger#3

See: https://pagure.io/fedora-ci/general/issue/451
