### PR TITLE
Drop package limit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,11 +43,6 @@ pipeline {
 
                     if (msg) {
 
-                        if (msg['update']['builds'].size() > 20) {
-                            echo "There are way too many (${msg['update']['builds'].size()} > 20) builds in the update. Skipping..."
-                            return
-                        }
-
                         msg['artifact']['builds'].each { build ->
                             allTaskIds.add(build['task_id'])
                         }


### PR DESCRIPTION
We believe the tool and the pipeline should now be capable of running on updates of any size. Let's drop the update size check and see what breaks.